### PR TITLE
Remove commands to set VSCode as git editor

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,6 @@ ARG VARIANT=buster
 FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
 
 
-ARG GIT_EDITOR_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/containers/codespaces-linux/.devcontainer/git-ed.sh"
 ARG SHELLCHECK_VERSION="v0.7.1"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update \
@@ -18,15 +17,8 @@ RUN apt-get update \
     && mkdir -p /tmp/shellcheck \
     && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJv -C /tmp/shellcheck/ \
     && install -m 755 /tmp/shellcheck/shellcheck-${SHELLCHECK_VERSION}/shellcheck /usr/local/bin/shellcheck \
-# Configure VSCode as the default editor for git commits
-# Adapted from https://github.com/microsoft/vscode-dev-containers/blob/master/containers/codespaces-linux/.devcontainer/Dockerfile
-    && mkdir -p /tmp/git-ed \
-    && wget -qO /tmp/git-ed/git-ed.sh ${GIT_EDITOR_SCRIPT_SOURCE} \
-    && install -m 755 /tmp/git-ed/git-ed.sh /usr/local/bin/git-ed.sh \
-    && git config --global core.editor "/usr/local/bin/git-ed.sh" \
 # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/shellcheck \
-    && rm -rf /tmp/git-ed


### PR DESCRIPTION
The commands were failing, causing the devcontainer to fail to start.
The git editor is better set in the user's [dotfiles][1] ([example][2])

[1]: https://docs.github.com/en/github/developing-online-with-codespaces/personalizing-codespaces-for-your-account
[2]: https://github.com/johnboyes/dotfiles/blob/master/.gitconfig