### PR TITLE
Fix releases bug

### DIFF
--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -37,7 +37,7 @@ jobs:
           go-version: 1.15
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.1.1
+        uses: goreleaser/goreleaser-action@v2.4.1
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
GitHub releases were not being created successfully.  Fix is to use
the latest version of the goreleaser action.