### PR TITLE
Fix releases process

### DIFF
--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -27,12 +27,12 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2.3.2
+        uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v2.1.2
+        uses: actions/setup-go@v2.1.3
         with:
           go-version: 1.15
       -


### PR DESCRIPTION
The previous commit did not fix the releases process, as there were
still some GitHub Actions dependencies which needed to be updated.
Updated the dependencies in this commit.