### PR TITLE
Fix broken release process

### DIFF
--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -37,9 +37,9 @@ jobs:
           go-version: 1.15
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.4.1
+        uses: goreleaser/goreleaser-action@v6
         with:
-          version: latest
-          args: release --rm-dist
+          version: '~> v2'
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,6 @@
 ---
 project_name: hoverfly-github-action
-build:
-  skip: true
+version: 2
 release:
   github:
   prerelease: auto


### PR DESCRIPTION
The fix is to use a more up to date version of goreleaser, which also
involves a minor change to our goreleaser config.