### PR TITLE
Fix broken release process - 2nd attempt

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,6 +1,8 @@
 ---
 project_name: hoverfly-github-action
 version: 2
+build:
+  skip: true
 release:
   github:
   prerelease: auto


### PR DESCRIPTION
In the previous commit we erroneously removed the instruction in the
goreleaser config to skip the goreleaser build.  This commit fixes the
problem by reinstating that instruction.