### PR TITLE
Fix releases for PRs from forks

### DIFF
--- a/.github/workflows/github_tag_and_release.yml
+++ b/.github/workflows/github_tag_and_release.yml
@@ -2,7 +2,7 @@
 name: Release
 
 on:  # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
     types:
       - closed
 


### PR DESCRIPTION
The [issue][1] was that a new release was not being created properly
when the PR came from a fork.

The fix is to trigger the release process on [`pull_request_target`][2]
rather than `pull_request`.  There are some [security concerns][3] to be
aware of when using `pull_request_target`, but they are not applicable
to our use case here, as we only trigger it when the PR is closed (which
means no danger that a malicious actor could run malicious code
without it having been reviewed).

[1]: https://github.com/SpectoLabs/hoverfly-github-action/actions/runs/13983200352
[2]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
[3]: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/