### PR TITLE
Use the Go minor version for Dependabot updates

### DIFF
--- a/.github/workflows/dependabot_hack.yml
+++ b/.github/workflows/dependabot_hack.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: koalaman/shellcheck@v0.10.0
 
       # update the version in `github_tag_and_release.yml` manually, too
-      - uses: golang/go@go1.24.1
+      - uses: golang/go@go1.24
 
       # update the variant version in the devcontainer.json manually, too
       # (see ../DEPENDENCIES.md#devcontainer-base-image-version for more info )


### PR DESCRIPTION
Prior to this commit Dependabot would create a pull request for every
new patch version of Go. In `github_tag_and_release.yml` we only specify
the minor version of Go though, so it is better to have Dependabot only
create pull requests when there is a new minor version.