### PR TITLE
Ignore Go patch version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every weekday
       interval: "daily"
+    ignore:
+      # ignore all Go patch updates
+      - dependency-name: "golang/go"
+        update-types: ["version-update:semver-patch"]
     labels:
       - "dependencies"
       - "patch"


### PR DESCRIPTION
Explicitly add an ignore instruction to the Dependabot config.