### PR TITLE
Use CODEOWNERS file as reviewers is deprecated

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @johnboyes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,5 +18,3 @@ updates:
     labels:
       - "dependencies"
       - "patch"
-    reviewers:
-      - "johnboyes"


### PR DESCRIPTION
The [reviewers Dependabot configuration option is now deprecated][1], so
as suggested we are now using a CODEOWNERS file to specify who gets
notified about pull requests, instead.

[1]: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/